### PR TITLE
change encoding to UTF-8

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,3 +9,5 @@ plugins:
 
 # Google Analytics
 google_analytics: UA-134749152-2
+
+encoding: UTF-8


### PR DESCRIPTION
recommended by https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/troubleshooting-jekyll-build-errors-for-github-pages-sites#file-is-not-properly-utf-8-encoded