### PR TITLE
add timezone info to conversion workshop

### DIFF
--- a/HCK19_2024_Remote/agenda/AGENDA.md
+++ b/HCK19_2024_Remote/agenda/AGENDA.md
@@ -1,4 +1,4 @@
-Below is the current draft of the agenda. [Download Agenda](agenda/2024_data_conversion_workshop_agenda.pdf)
+Below is the current draft of the agenda. All times are in Pacific Time (PT, UTC-7). [Download Agenda](agenda/2024_data_conversion_workshop_agenda.pdf)
 
 ### Agenda
 


### PR DESCRIPTION
The data conversion workshop agenda was missing timezone information.